### PR TITLE
Add Aurora PostgreSQL Serverless v2 CDK stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,8 +569,18 @@ CREATE INDEX idx_jan_code ON jan_url_mapping(jan_code);
 ## インフラ管理方針
 
 ### Infrastructure as Code（IaC）
-- **不使用**: AWSマネジメントコンソールで手動構築
-- 理由: 小規模構成、コンソール操作による柔軟な対応を優先
+- **使用**: AWS CDK（Python）
+- **スタック構成**:
+  - **NetworkStack**: VPC、サブネット、セキュリティグループ
+  - **DatabaseStack**: Aurora PostgreSQL Serverless v2
+  - **ApiStack**: Lambda + API Gateway
+  - **FrontendStack**: S3 + CloudFront
+- **デプロイコマンド**:
+  ```bash
+  cd cdk_app
+  cdk deploy --all  # 全スタックをデプロイ
+  cdk deploy BronzedrawDatabaseStack-dev  # Database Stackのみデプロイ
+  ```
 
 ### ドキュメント
 - 構築手順書（本要件定義書に基づく）

--- a/cdk_app/app.py
+++ b/cdk_app/app.py
@@ -3,8 +3,9 @@ import os
 import aws_cdk as cdk
 
 from stacks.network_stack import NetworkStack
-from stacks.frontend_stack import FrontendStack
+from stacks.database_stack import DatabaseStack
 from stacks.api_stack import ApiStack
+from stacks.frontend_stack import FrontendStack
 
 # 環境設定
 ENV_NAME = os.getenv("ENV_NAME", "dev")  # dev, stg, prod
@@ -21,32 +22,47 @@ env = cdk.Environment(
 # NetworkStack（VPC、サブネット、セキュリティグループ）
 network_stack = NetworkStack(
     app,
-    f"SilverloseNetworkStack-{ENV_NAME}",
+    f"BronzedrawNetworkStack-{ENV_NAME}",
     env_name=ENV_NAME,
     env=env,
-    description=f"Silverlose Network Stack for {ENV_NAME} environment",
+    description=f"Bronzedraw Network Stack for {ENV_NAME} environment",
 )
+
+# DatabaseStack（Aurora PostgreSQL Serverless v2）
+database_stack = DatabaseStack(
+    app,
+    f"BronzedrawDatabaseStack-{ENV_NAME}",
+    env_name=ENV_NAME,
+    vpc=network_stack.vpc,
+    aurora_sg=network_stack.aurora_sg,
+    env=env,
+    description=f"Bronzedraw Database Stack for {ENV_NAME} environment",
+)
+database_stack.add_dependency(network_stack)
 
 # ApiStack（Lambda + API Gateway）
 api_stack = ApiStack(
     app,
-    f"SilverloseApiStack-{ENV_NAME}",
+    f"BronzedrawApiStack-{ENV_NAME}",
     env_name=ENV_NAME,
     vpc=network_stack.vpc,
     lambda_sg=network_stack.lambda_sg,
+    db_cluster=database_stack.db_cluster,
+    db_secret=database_stack.db_secret,
     env=env,
-    description=f"Silverlose API Stack for {ENV_NAME} environment",
+    description=f"Bronzedraw API Stack for {ENV_NAME} environment",
 )
 api_stack.add_dependency(network_stack)
+api_stack.add_dependency(database_stack)
 
 # FrontendStack（S3 + CloudFront）
 frontend_stack = FrontendStack(
     app,
-    f"SilverloseFrontendStack-{ENV_NAME}",
+    f"BronzedrawFrontendStack-{ENV_NAME}",
     env_name=ENV_NAME,
     api_url=api_stack.api.url,
     env=env,
-    description=f"Silverlose Frontend Stack for {ENV_NAME} environment",
+    description=f"Bronzedraw Frontend Stack for {ENV_NAME} environment",
 )
 frontend_stack.add_dependency(api_stack)
 

--- a/cdk_app/stacks/database_stack.py
+++ b/cdk_app/stacks/database_stack.py
@@ -1,0 +1,86 @@
+from aws_cdk import (
+    Stack,
+    Duration,
+    RemovalPolicy,
+    SecretValue,
+    aws_ec2 as ec2,
+    aws_rds as rds,
+    aws_secretsmanager as secretsmanager,
+    Tags,
+)
+from constructs import Construct
+
+
+class DatabaseStack(Stack):
+    """
+    Aurora PostgreSQL Serverless v2 を作成するスタック
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        env_name: str = "dev",
+        vpc: ec2.Vpc = None,
+        aurora_sg: ec2.SecurityGroup = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.env_name = env_name
+
+        # データベース認証情報をSecrets Managerに保存
+        self.db_secret = secretsmanager.Secret(
+            self,
+            f"AuroraSecret-{env_name}",
+            secret_name=f"bronzedraw-aurora-{env_name}",
+            description=f"Aurora PostgreSQL credentials for {env_name}",
+            generate_secret_string=secretsmanager.SecretStringGenerator(
+                secret_string_template='{"username":"bronzedraw"}',
+                generate_string_key="password",
+                exclude_punctuation=True,
+                password_length=32,
+            ),
+        )
+
+        # Aurora PostgreSQL Serverless v2 クラスター
+        self.db_cluster = rds.DatabaseCluster(
+            self,
+            f"AuroraCluster-{env_name}",
+            cluster_identifier=f"bronzedraw-aurora-{env_name}",
+            engine=rds.DatabaseClusterEngine.aurora_postgres(
+                version=rds.AuroraPostgresEngineVersion.VER_16_6
+            ),
+            credentials=rds.Credentials.from_secret(self.db_secret),
+            default_database_name="bronzedraw",
+            writer=rds.ClusterInstance.serverless_v2(
+                f"Writer-{env_name}",
+                enable_performance_insights=True,
+                performance_insight_retention=rds.PerformanceInsightRetention.DEFAULT,  # 7日間
+            ),
+            readers=[
+                rds.ClusterInstance.serverless_v2(
+                    f"Reader-{env_name}",
+                    scale_with_writer=True,  # Writerに合わせてスケーリング
+                    enable_performance_insights=True,
+                    performance_insight_retention=rds.PerformanceInsightRetention.DEFAULT,
+                ),
+            ] if env_name == "prod" else [],  # dev環境はreaderなし
+            serverless_v2_min_capacity=0.5,  # 最小ACU
+            serverless_v2_max_capacity=1.0 if env_name == "dev" else 2.0,  # 最大ACU
+            vpc=vpc,
+            vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
+            security_groups=[aurora_sg] if aurora_sg else None,
+            backup=rds.BackupProps(
+                retention=Duration.days(7 if env_name == "prod" else 1),
+                preferred_window="17:00-18:00",  # JST 02:00-03:00
+            ),
+            preferred_maintenance_window="Sun:18:00-Sun:19:00",  # JST 日曜 03:00-04:00
+            cloudwatch_logs_exports=["postgresql"],  # CloudWatch Logsにログ出力
+            removal_policy=RemovalPolicy.SNAPSHOT if env_name == "prod" else RemovalPolicy.DESTROY,
+            deletion_protection=True if env_name == "prod" else False,
+        )
+
+        # タグ追加
+        Tags.of(self).add("Env", env_name)
+        Tags.of(self).add("Project", "bronzedraw")


### PR DESCRIPTION
- Create DatabaseStack with Aurora PostgreSQL Serverless v2 cluster
  - Configure Serverless v2 with 0.5-2.0 ACU range
  - Enable Performance Insights and CloudWatch Logs
  - Set up Secrets Manager for credentials
  - Configure automatic backups and maintenance windows
  - Add reader instance for production environment
- Update ApiStack to integrate with Aurora
  - Add DB cluster and secret parameters
  - Grant Lambda permission to read from Secrets Manager
  - Set DB_SECRET_ARN and DB_CLUSTER_ENDPOINT environment variables
- Update app.py to include DatabaseStack in deployment
  - Rename all stack identifiers from Silverlose to Bronzedraw
  - Add proper stack dependencies
- Update README with CDK deployment information

Fixes #3